### PR TITLE
poetry related changes

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,8 +8,6 @@ on:
 
 env:
   FORCE_COLOR: 1
-  XDG_CACHE_HOME: ${{ github.workspace }}/cache
-  PIP_CACHE_DIR: ${{ github.workspace }}/pip-cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,21 +51,14 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-      - name: Cache pip
+      - name: Cache XDG_CACHE_HOME
         uses: actions/cache@v3
         with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: ${{ matrix.os }}-pip-${{ matrix.python-version }}-v1-${{
-            hashFiles('**/setup.py', '**/*requirements*.txt') }}
+          path: ~/.cache
+          key: ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock', '**/with-fuseki.sh', '**/*requirements*.txt') }}
           restore-keys: |
-            ${{ matrix.os }}-pip-${{ matrix.python-version }}-v1-
-      - name: Cache xdg
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.XDG_CACHE_HOME }}
-          key: ${{ matrix.os }}-xdg-v1-${{ hashFiles('**/with-fuseki.sh') }}
-          restore-keys: |
-            ${{ matrix.os }}-xdg-v1-
+            ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-
+            ${{ github.job }}-xdg-v1-${{ matrix.os }}-
       - name: Install Task
         uses: arduino/setup-task@v1
         with:
@@ -96,6 +87,8 @@ jobs:
           name: ${{ matrix.python-version }}-${{ matrix.os }}-pytest-junit-xml
           path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}-pytest-junit.xml
   extra-tasks:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -109,14 +102,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip
+      - name: Python Poetry Action
+        uses: snok/install-poetry@v1
+      - name: Cache XDG_CACHE_HOME
         uses: actions/cache@v3
         with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: tox-${{ matrix.task }}-pip-v1-${{
-            hashFiles('**/setup.py', '**/requirements*.txt') }}
+          path: ~/.cache
+          key: ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock', '**/with-fuseki.sh', '**/*requirements*.txt') }}
           restore-keys: |
-            tox-${{ matrix.task }}-pip-v1-
+            ${{ github.job }}-xdg-v1-${{ matrix.os }}-${{ matrix.python-version }}-
+            ${{ github.job }}-xdg-v1-${{ matrix.os }}-
       - name: Install Task
         uses: arduino/setup-task@v1
         with:

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -47,16 +47,3 @@ RUN \
         poetry==1.3.1 \
         && \
     true
-
-COPY pyproject.toml poetry.lock ./
-
-RUN poetry export \
-    -E dev \
-    -E tests \
-    -E docs \
-    --output /var/tmp/requirements-via-poetry-including-all-dev.txt
-RUN \
-    python -m pip install \
-        -r /var/tmp/requirements-via-poetry-including-all-dev.txt \
-        && \
-    true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,23 +6,19 @@ version: "3"
 vars:
   TASKFILE_DIR:
     sh: pwd
-  # The path to the virtual environment to use when using a virtual
-  # environment.
-  VENV_PATH: '{{(env "VENV_PATH") | default (osClean (print .TASKFILE_DIR "/.venv"))}}'
-  # Non empty string results in tasks using a virtual environment.
-  WITH_VENV: '{{env "WITH_VENV" | default "false"}}'
-  # The virtual environemtn specific python interpreter to use.
-  VENV_BINPREFIX: '{{if (mustFromJson .WITH_VENV)}}{{if (eq OS "windows")}}{{.VENV_PATH}}/Scripts/{{else}}{{.VENV_PATH}}/bin/{{end}}{{end}}'
-  VENV_PYTHON: '{{if (eq OS "windows")}}{{.VENV_BINPREFIX}}python.exe{{else}}{{.VENV_BINPREFIX}}python{{end}}'
-  # The python interpreter to use.
+  POETRY: poetry
+  # The prefix to use when running dev commands
+  RUN_PREFIX: "{{.POETRY}} run"
+  # The python to use for running in the venv
+  VENV_PYTHON: "{{.RUN_PREFIX}} python"
+    # The python interpreter to use.
   PYTHON: python
-  _PYTHON: "{{if (mustFromJson .WITH_VENV)}}{{.VENV_PYTHON}}{{else}}{{.PYTHON}}{{end}}"
   # Truthish values ("true", "1", etc.) results in java being installed as a
   # system dependency.
   INSTALL_SYSTEM_DEPS_JAVA: "false"
   # Truthish values ("true", "1", etc.) results in extras being installed with
   # pip.
-  INSTALL_PIP_EXTRAS: "false"
+  INSTALL_EXTRAS: "false"
   # Truthish values ("true", "1", etc.) results in extensive tests being ran and
   # dependencies for extensive tests being installed.
   EXTENSIVE: "false"
@@ -61,60 +57,40 @@ tasks:
   install:tox:
     desc: Install tox
     cmds:
-      - "{{._PYTHON | shellQuote}} -m pip install tox {{if (mustFromJson .WITH_GITHUB_ACTIONS)}}tox-gh-actions{{end}}"
+      - "{{.PYTHON}} -m pip install tox {{if (mustFromJson .WITH_GITHUB_ACTIONS)}}tox-gh-actions{{end}}"
 
-  install:pip-deps:
-    desc: Install pip dependencies
+  poetry:configure:
+    desc: Configure the environment for development with poetry
     cmds:
-      - "poetry export -E dev -E tests -E docs {{if (mustFromJson .INSTALL_PIP_EXTRAS)}}-E berkeleydb -E networkx{{end}} --output /var/tmp/requirements-via-poetry-incl-dev.txt"
-      - "{{._PYTHON | shellQuote}} -m pip install --upgrade -r /var/tmp/requirements-via-poetry-incl-dev.txt"
+      - |
+        {{if .POETRY_PYTHON}} {{.POETRY}} env use {{.POETRY_PYTHON}} {{end}}
+        {{.POETRY}} install {{if (or (mustFromJson .INSTALL_EXTRAS) (mustFromJson .EXTENSIVE))}} --all-extras{{end}} {{.CLI_ARGS}}
 
-  install:flake8:
-    desc: Install flake8 dependencies
+  configure:
+    desc: Configure the environment for development
     cmds:
-      - poetry export --only flake8 --output /var/tmp/requirements.flake8.txt
-      - "{{._PYTHON | shellQuote}} -m pip install --upgrade -r /var/tmp/requirements.flake8.txt"
-
-  install:deps:
-    desc: Install all dependencies
-    cmds:
-      - task: install:system-deps
-      - task: install:tox
-      - task: install:pip-deps
-
-  venv:create:
-    desc: Create a venv to VENV_PATH(={{.VENV_PATH}})
-    cmds:
-      - "{{.PYTHON | shellQuote}} -m venv {{.VENV_PATH}}"
+      - task: venv:install
 
   venv:install:
-    desc: Create and install a venv to VENV_PATH(={{.VENV_PATH}})
+    desc: Create and install a venv
     cmds:
-      - task: venv:create
-      - task: install:pip-deps
-        vars: { _PYTHON: "{{.VENV_PYTHON}}" }
+      - task: poetry:configure
 
   venv:clean:
-    desc: Remove the venv at VENV_PATH(={{.VENV_PATH}})
+    desc: Clean the virtual environment
     cmds:
-      - task: _rimraf
-        vars: { _PYTHON: "{{.PYTHON}}", RIMRAF_TARGET: "{{.VENV_PATH}}" }
+      - "{{.POETRY}} env remove --all {{.CLI_ARGS}}"
 
   venv:run:
     desc: Run a command inside the venv
     cmds:
       - cmd: |
-          VIRTUAL_ENV="{{.VENV_PATH}}" PATH="{{.VENV_PATH}}/bin${PATH:+:${PATH}}" {{.CLI_ARGS}}
+          {{.RUN_PREFIX}} {{.CLI_ARGS}}
 
   run:
     desc: Run a command. If WITH_VENV is truthish, the command will be run inside the virtual environment.
     cmds:
-      - cmd: |
-          {{if (mustFromJson .WITH_VENV)}}
-          VIRTUAL_ENV="{{.VENV_PATH}}" PATH="{{.VENV_PATH}}/bin${PATH:+:${PATH}}" {{.CLI_ARGS}}
-          {{else}}
-          {{.CLI_ARGS}}
-          {{end}}
+      - task: venv:run
 
   tox:
     desc: Run tox
@@ -126,7 +102,7 @@ tasks:
         {{if .TOX_JUNIT_XML_PREFIX}}TOX_JUNIT_XML_PREFIX={{shellQuote .TOX_JUNIT_XML_PREFIX}}{{end}} \
         {{if .COVERAGE_FILE}}COVERAGE_FILE={{shellQuote .COVERAGE_FILE}}{{end}} \
         {{.TEST_HARNESS}} \
-        {{._PYTHON | shellQuote}} \
+        {{.PYTHON | shellQuote}} \
           -m tox \
           {{.CLI_ARGS}}
     env:
@@ -134,30 +110,30 @@ tasks:
   test:
     desc: Run tests
     cmds:
-      - '{{.TEST_HARNESS}}{{print .VENV_BINPREFIX "pytest" | shellQuote}} {{if (mustFromJson .WITH_COVERAGE)}}--cov --cov-report={{end}} {{.CLI_ARGS}}'
+      - '{{.TEST_HARNESS}}{{.RUN_PREFIX}} pytest {{if (mustFromJson .WITH_COVERAGE)}}--cov --cov-report={{end}} {{.CLI_ARGS}}'
   flake8:
     desc: Run flake8
     cmds:
       - |
-        if {{._PYTHON | shellQuote}} -c 'import importlib; exit(0 if importlib.util.find_spec("flakeheaven") is not None else 1)'
+        if {{.VENV_PYTHON}} -c 'import importlib.util; exit(0 if importlib.util.find_spec("flakeheaven") is not None else 1)'
         then
           1>&2 echo "running flakeheaven"
-          {{._PYTHON | shellQuote}} -m flakeheaven lint {{.CLI_ARGS}}
+          {{.VENV_PYTHON}} -m flakeheaven lint {{.CLI_ARGS}}
         else
           1>&2 echo "skipping flakeheaven as it is not installed, likely because python version is older than 3.8"
         fi
   black:
     desc: Run black
     cmds:
-      - '{{._PYTHON | shellQuote}} -m black {{if (mustFromJson (.CHECK | default "false"))}}--check --diff {{end}}{{.CLI_ARGS | default "."}}'
+      - '{{.VENV_PYTHON}} -m black {{if (mustFromJson (.CHECK | default "false"))}}--check --diff {{end}}{{.CLI_ARGS | default "."}}'
   isort:
     desc: Run isort
     cmds:
-      - '{{._PYTHON | shellQuote}} -m isort {{if (mustFromJson (.CHECK | default "false"))}}--check --diff {{end}}{{.CLI_ARGS | default "."}}'
+      - '{{.VENV_PYTHON}} -m isort {{if (mustFromJson (.CHECK | default "false"))}}--check --diff {{end}}{{.CLI_ARGS | default "."}}'
   mypy:
     desc: Run mypy
     cmds:
-      - "{{._PYTHON | shellQuote}} -m mypy --show-error-context --show-error-codes {{.CLI_ARGS}}"
+      - "{{.VENV_PYTHON}} -m mypy --show-error-context --show-error-codes {{.CLI_ARGS}}"
 
   lint:fix:
     desc: Fix auto-fixable linting errors
@@ -201,7 +177,7 @@ tasks:
     desc: Build documentation
     cmds:
       - echo "PYTHONPATH=${PYTHONPATH}"
-      - "{{._PYTHON | shellQuote}} -m sphinx.cmd.build -b html -d docs/_build/doctrees docs/ docs/_build/html -W {{.CLI_ARGS}}"
+      - "{{.VENV_PYTHON}} -m sphinx.cmd.build -T -W -b html -d docs/_build/doctree docs docs/_build/html {{.CLI_ARGS}}"
 
   docs:live-server:
     desc: Run a live server on generated docs
@@ -244,7 +220,7 @@ tasks:
   test:data:fetch:
     desc: Fetch test data.
     cmds:
-      - "{{._PYTHON}} test/data/fetcher.py {{.CLI_ARGS}}"
+      - "{{.VENV_PYTHON}} test/data/fetcher.py {{.CLI_ARGS}}"
 
   pre-commit:install:
     desc: Install pre-commit hooks
@@ -272,7 +248,7 @@ tasks:
       - task: install:tox
         vars:
           WITH_GITHUB_ACTIONS: true
-      - cmd: "{{._PYTHON | shellQuote}} -m pip install coveralls"
+      - cmd: "{{.PYTHON}} -m pip install coveralls"
       - task: tox
         vars:
           COVERAGE_FILE: ".coverage"
@@ -281,13 +257,15 @@ tasks:
   gha:flake8:
     desc: GitHub Actions flake8 workflow
     cmds:
-      - task: install:flake8
+      - task: poetry:configure
+        vars:
+          .CLI_ARGS: --no-root --only=flake8
       - task: flake8
 
   cmd:rdfpipe:
     desc: Run rdfpipe
     cmds:
-      - cmd: "{{._PYTHON | shellQuote}} -m rdflib.tools.rdfpipe {{.CLI_ARGS}}"
+      - cmd: "{{.VENV_PYTHON}} -m rdflib.tools.rdfpipe {{.CLI_ARGS}}"
 
   pip-compile:
     cmds:
@@ -356,7 +334,7 @@ tasks:
     # a python interpreter. The name is inspired by
     # <https://www.npmjs.com/package/rimraf>.
     - cmd: |
-        {{._PYTHON | shellQuote}} -c '
+        {{.PYTHON}} -c '
         from pathlib import Path;
         import sys, shutil;
         for path in sys.argv[1:]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile.devcontainer
     working_dir: /srv/workspace
+    environment:
+      - POETRY_VIRTUALENVS_IN_PROJECT=1
     volumes:
       - .:/srv/workspace:z,cached
       - xdg-cache-home:/root/.cache

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,7 +262,12 @@ suppress_warnings = [
     "ref.python",
 ]
 
-nitpicky = True
+if sys.version_info < (3, 8):
+    # Being nitpicky on python 3.7 causes lots of problems with Sphinx 4, so
+    # turn it off there.
+    nitpicky = False
+else:
+    nitpicky = True
 
 nitpick_ignore = [
     ("py:data", "typing.Literal"),
@@ -308,12 +313,5 @@ if sys.version_info < (3, 9):
             ("py:class", "_TripleType"),
             ("py:class", "_TripleOrTriplePathType"),
             ("py:class", "TextIO"),
-        ]
-    )
-
-if sys.version_info < (3, 8):
-    nitpick_ignore.extend(
-        [
-            ("py:class", "importlib_metadata.EntryPoint"),
         ]
     )

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -14,6 +14,7 @@ developing RDFLib code.
 * Code should also pass `flake8 <https://flake8.pycqa.org/en/latest/>`_ linting
   and `mypy <http://mypy-lang.org/>`_ type checking.
 * You must supply tests for new code.
+* RDFLib uses `Poetry <https://python-poetry.org/docs/master/>`_ for dependency management and packaging.
 
 If you add a new cool feature, consider also adding an example in ``./examples``
 
@@ -95,25 +96,24 @@ To run RDFLib's test suite with `pytest <https://docs.pytest.org/en/latest/>`_:
 
 .. code-block:: console
 
-   $ pip install -r requirements.txt -r requirements.dev.txt
-   $ pytest
+   $ poetry install
+   $ poetry run pytest
 
 Specific tests can be run by file name. For example:
 
 .. code-block:: console
 
-  $ pytest test/test_graph.py
+  $ poetry run test/test_graph/test_graph.py
 
 For more extensive tests, including tests for the `berkleydb
 <https://www.oracle.com/database/technologies/related/berkeleydb.html>`_
-backend, install the requirements from ``requirements.dev-extra.txt`` before
+backend, install extra requirements before
 executing the tests.
 
 .. code-block:: console
 
-   $ pip install -r requirements.txt -r requirements.dev.txt
-   $ pip install -r requirements.dev-extra.txt
-   $ pytest
+   $ poetry install --all-extras
+   $ poetry run pytest
 
 Writing tests
 ~~~~~~~~~~~~~
@@ -143,13 +143,13 @@ our black.toml config file:
 
 .. code-block:: bash
 
-    python -m black --config black.toml --check ./rdflib
+    poetry run black .
 
 Check style and conventions with `flake8 <https://flake8.pycqa.org/en/latest/>`_:
 
 .. code-block:: bash
 
-    python -m flake8 rdflib
+    poetry run flake8 rdflib
 
 We also provide a `flakeheaven <https://pypi.org/project/flakeheaven/>`_
 baseline that ignores existing flake8 errors and only reports on newly
@@ -157,14 +157,14 @@ introduced flake8 errors:
 
 .. code-block:: bash
 
-    python -m flakeheaven
+    poetry run flakeheaven
 
 
 Check types with `mypy <http://mypy-lang.org/>`_:
 
 .. code-block:: bash
 
-    python -m mypy --show-error-context --show-error-codes rdflib
+    poetry run mypy --show-error-context --show-error-codes
 
 pre-commit and pre-commit ci
 ----------------------------
@@ -252,21 +252,14 @@ Some useful commands for working with the task in the taskfile is given below:
     # List available tasks.
     task -l
 
-    # Install pip dependencies
-    task install:pip-deps
+    # Configure the environment for development
+    task configure
 
     # Run basic validation
     task validate
 
-    # Install a venv and run validation inside venv
-    task venv:install
-    task WITH_VENV=1 validate
-
-    # Fix all auto-fixable validation errors (i.e. run black and isort) using venv
-    task WITH_VENV=1 validate:fix
-
-    # Build docs inside venv
-    task WITH_VENV=1 docs:build
+    # Build docs
+    task docs:build
 
     # Run live-preview on the docs
     task docs:live-server
@@ -302,6 +295,9 @@ To use the development container directly:
 
     # Build the devcontainer docker image.
     docker-compose build
+
+    # Configure the system for development.
+    docker-compose run --rm devcontainer task configure
 
     # Run the validate task inside the devtools container.
     docker-compose run --rm devcontainer task validate

--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -16,25 +16,18 @@ for the Shinx documentation about these fields.
 Building
 --------
 
-To build you must have the ``sphinx`` and some additional package installed. 
-The full set of requirements is listed in the ``sphinx-requirements.txt`` file 
-within the :file:`docs/` directory.
-
-To install the requirements for building documentation run:
+To build the documentation you can use Sphinx from within the poetry environment. To do this, run the following commands:
 
 .. code-block:: bash
 
-  pip install -r docs/sphinx-requirements.txt
+    # Install poetry venv
+    poetry install
+
+    # Build the sphinx docs
+    poetry run sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
 
 
-Once you have all the requirements installed you can run this command in the 
-rdflib root directory:
-
-.. code-block:: bash
-
-  python setup.py build_sphinx
-
-Docs will be generated in :file:`build/sphinx/html/` and API documentation, 
+Docs will be generated in :file:`docs/_build/html` and API documentation, 
 generated from doc-strings, will be placed in :file:`docs/apidocs/`.
 
 There is also a `tox <https://tox.wiki/en/latest/>`_ environment for building 
@@ -51,7 +44,7 @@ API Docs are automatically generated with ``sphinx-apidoc``:
 
 .. code-block:: bash
 
-   sphinx-apidoc -f -d 10 -o docs/apidocs/ rdflib examples
+   poetry run sphinx-apidoc -f -d 10 -o docs/apidocs/ rdflib examples
 
 Note that ``rdflib.rst`` was manually tweaked so as to not include all
  imports in ``rdflib/__init__.py``.

--- a/poetry.lock
+++ b/poetry.lock
@@ -5,7 +5,7 @@ name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
@@ -36,7 +36,7 @@ name = "babel"
 version = "2.11.0"
 description = "Internationalization utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "Babel-2.11.0-py3-none-any.whl", hash = "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe"},
@@ -62,7 +62,7 @@ name = "black"
 version = "22.12.0"
 description = "The uncompromising code formatter."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
@@ -99,7 +99,7 @@ name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
@@ -111,7 +111,7 @@ name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6.0"
 files = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
@@ -126,7 +126,7 @@ name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
@@ -221,7 +221,7 @@ name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
@@ -324,7 +324,7 @@ name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -336,7 +336,7 @@ name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -395,7 +395,7 @@ name = "isort"
 version = "5.11.4"
 description = "A Python utility / library to sort Python imports."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7.0"
 files = [
     {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
@@ -413,7 +413,7 @@ name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -431,7 +431,7 @@ name = "markdown-it-py"
 version = "2.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
@@ -457,7 +457,7 @@ name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -519,7 +519,7 @@ name = "mdit-py-plugins"
 version = "0.3.3"
 description = "Collection of plugins for markdown-it-py"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
@@ -539,7 +539,7 @@ name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -551,7 +551,7 @@ name = "mypy"
 version = "0.991"
 description = "Optional static typing for Python"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
@@ -603,7 +603,7 @@ name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -615,7 +615,7 @@ name = "myst-parser"
 version = "0.18.1"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "myst-parser-0.18.1.tar.gz", hash = "sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d"},
@@ -657,30 +657,11 @@ extra = ["lxml (>=4.5)", "pydot (>=1.4.1)", "pygraphviz (>=1.7)"]
 test = ["codecov (>=2.1)", "pytest (>=6.2)", "pytest-cov (>=2.12)"]
 
 [[package]]
-name = "networkx"
-version = "2.8.8"
-description = "Python package for creating and manipulating graphs and networks"
-category = "main"
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "networkx-2.8.8-py3-none-any.whl", hash = "sha256:e435dfa75b1d7195c7b8378c3859f0445cd88c6b0375c181ed66823a9ceb7524"},
-    {file = "networkx-2.8.8.tar.gz", hash = "sha256:230d388117af870fce5647a3c52401fcf753e94720e6ea6b4197a5355648885e"},
-]
-
-[package.extras]
-default = ["matplotlib (>=3.4)", "numpy (>=1.19)", "pandas (>=1.3)", "scipy (>=1.8)"]
-developer = ["mypy (>=0.982)", "pre-commit (>=2.20)"]
-doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.2)", "pydata-sphinx-theme (>=0.11)", "sphinx (>=5.2)", "sphinx-gallery (>=0.11)", "texext (>=0.6.6)"]
-extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.9)", "sympy (>=1.10)"]
-test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
-
-[[package]]
 name = "packaging"
 version = "22.0"
 description = "Core utilities for Python packages"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
@@ -692,7 +673,7 @@ name = "pathspec"
 version = "0.10.3"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
@@ -704,7 +685,7 @@ name = "pbr"
 version = "5.11.0"
 description = "Python Build Reasonableness"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.6"
 files = [
     {file = "pbr-5.11.0-py2.py3-none-any.whl", hash = "sha256:db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a"},
@@ -731,7 +712,7 @@ name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
@@ -867,7 +848,7 @@ name = "pytz"
 version = "2022.7"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "pytz-2022.7-py2.py3-none-any.whl", hash = "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"},
@@ -879,7 +860,7 @@ name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -889,6 +870,13 @@ files = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -922,7 +910,7 @@ name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7, <4"
 files = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
@@ -944,7 +932,7 @@ name = "setuptools"
 version = "65.6.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
@@ -973,7 +961,7 @@ name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -985,7 +973,7 @@ name = "sphinx"
 version = "4.3.2"
 description = "Python documentation generator"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
@@ -1021,7 +1009,7 @@ name = "sphinx-autodoc-typehints"
 version = "1.17.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "sphinx_autodoc_typehints-1.17.1-py3-none-any.whl", hash = "sha256:f16491cad05a13f4825ecdf9ee4ff02925d9a3b1cf103d4d02f2f81802cce653"},
@@ -1040,7 +1028,7 @@ name = "sphinxcontrib-apidoc"
 version = "0.3.0"
 description = "A Sphinx extension for running 'sphinx-apidoc' on each build"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "sphinxcontrib-apidoc-0.3.0.tar.gz", hash = "sha256:729bf592cf7b7dd57c4c05794f732dc026127275d785c2a5494521fdde773fb9"},
@@ -1056,7 +1044,7 @@ name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -1072,7 +1060,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -1088,7 +1076,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
@@ -1104,7 +1092,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -1119,7 +1107,7 @@ name = "sphinxcontrib-kroki"
 version = "1.3.0"
 description = "Kroki integration into sphinx"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "sphinxcontrib-kroki-1.3.0.tar.gz", hash = "sha256:90ce45e1f5822443772d4df8ddf031746101dc1fd5a0a831a1db7e0886c49b6a"},
@@ -1139,7 +1127,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
@@ -1155,7 +1143,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
@@ -1183,7 +1171,7 @@ name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
@@ -1195,7 +1183,7 @@ name = "typed-ast"
 version = "1.5.4"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
@@ -1286,10 +1274,10 @@ berkeleydb = ["berkeleydb"]
 dev = ["black", "flake8", "flakeheaven", "isort", "mypy", "pep8-naming"]
 docs = ["sphinx", "myst-parser", "sphinxcontrib-apidoc", "sphinxcontrib-kroki", "sphinx-autodoc-typehints"]
 html = ["html5lib"]
-networkx = ["networkx", "networkx"]
+networkx = ["networkx"]
 tests = ["html5lib", "pytest", "pytest-cov", "coverage"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "11a38283a275d65d5f3a7f2c550155ed797e78c5c1b4bb0838ed9d95b5d1bed0"
+content-hash = "59458e052797370fe5fd81a7a40d695f1f451d7fb052ae43ab136a8546e658b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,7 @@ pyparsing = "^3.0.9"
 #setuptools  # not needed anymore?
 importlib_metadata = {version = "^4.2.0", python = ">=3.7,<3.8"}
 berkeleydb = {version = "^18.1.5", optional = true}
-networkx = [
-    {version = "^2.6.2", python = ">3.7,<3.8", optional = true},
-    {version = "^2.8.8", python = "^3.8", optional = true},
-]
+networkx = {version = "^2.6.2", optional = true}
 html5lib = {version = "^1.1", optional = true}
 black = {version = "22.12.0", optional = true}
 flake8 = {version = ">=4.0.1", optional = true}  # flakeheaven is incompatible with flake8 >=5.0 (https://github.com/flakeheaven/flakeheaven/issues/132)
@@ -56,6 +53,22 @@ sphinx-autodoc-typehints = {version = "^1.17.1", optional = true}
 pytest = {version = "^7.1.3", optional = true}
 pytest-cov = {version = "^4.0.0", optional = true}
 coverage = {version = "^7.0.1", extras = ["toml"], optional = true}
+
+[tool.poetry.group.dev.dependencies]
+# These dependencies are added here so that `poetry install` behaves as
+# expected, which is that it creates a usable development environment. The
+# version constrainsts from `[tool.poetry.dependencies]` are used.
+black = "*"
+flake8 = "*"
+flakeheaven = "*"
+isort = "*"
+mypy = "*"
+pep8-naming = "*"
+sphinx = "*"
+myst-parser = "*"
+sphinxcontrib-apidoc = "*"
+sphinxcontrib-kroki = "*"
+sphinx-autodoc-typehints = "*"
 
 [tool.poetry.group.flake8.dependencies]
 flake8 = ">=4.0.1" # flakeheaven is incompatible with flake8 >=5.0 (https://github.com/flakeheaven/flakeheaven/issues/132)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
     {env:TOX_EXTRA_COMMAND:}
     {env:TOX_MYPY_COMMAND:{envpython} -m mypy --show-error-context --show-error-codes --junit-xml=test_reports/{env:TOX_JUNIT_XML_PREFIX:}mypy-junit.xml}
     {posargs:{envpython} -m pytest -ra --tb=native {env:TOX_PYTEST_ARGS:--junit-xml=test_reports/{env:TOX_JUNIT_XML_PREFIX:}pytest-junit.xml --cov --cov-report=}}
-    docs: sphinx-build -n -T -W -b html -d {envdir}/doctree docs docs/_build/html
+    docs: sphinx-build -T -W -b html -d {envdir}/doctree docs docs/_build/html
 
 [testenv:covreport]
 extras = tests


### PR DESCRIPTION
- `.github/workflows/validate.yaml`:
  - Cache the default `XDG_CACHE_HOME` instead of messing with `PIP_CACHE_DIR` and the variable. This simplifies caching quite a bit and also ensures caching works for poetry.
  - Install poetry for `extra-tasks`, so that poetry install works correctly.
  - Get an auth token in `extra-tasks` so we don't get hit by rate limiting.
- `docs/conf.py`:
  - Disable nit picking on pre-python 3.8 as this causes problems with older sphinx.
- `docs/developers.rst` and `docs/docs.rst`:
  - Incorporate poetry into instructions.
- `docker-compose.yml`:
  - Set `POETRY_VIRTUALENVS_IN_PROJECT=1` so that the `.venv` goes into a docker volume instead of going to emphemeral storage.
- `Dockerfile.devcontainer`
  - Don't install dependencies globally. With poetry, everyone should use poetry, and when using poetry the global python environment should not be used, so if people use the devcontainer correctly the global dependencies should have no effect.
- `poetry.lock`
  - Ran `poetry lock` after changes to `pyproject.toml`, most notable change is the stuff added to the dev Poetry dependency group is no longer optional.
- `pyproject.toml`:
  - Simplified the dependency constrains for `networkx` as this was causing problems with tox, as tox was running pip install with `'networkx<3.0.0,>=2.6.2; (python_version >= "3.7" and python_version < "3.8") and extra == "networkx"' 'networkx<3.0.0,>=2.8.8; (python_version >= "3.8" and python_version < "4.0") and extra == "networkx"'` and the `extra == "networkx"` here would never be true.
  - Added a `dev` poetry dependendcy group with everything that is needed for a sane development environment so that `poetry install` gets you a sane dev environment.
- `Taskfile.yml`:
  - Changed the commands so that everything works as before but now instead runs things with poetry.
  - Removed the legacy venv handling and replaced it with poetry equivalents.
- `tox.ini`:
  - Don't set nitpicky (`-n`) on the command line as it is being set conditionally on python version in `docs/conf.py` now.

