### PR TITLE
test minimum versions and decrease the lower bounds for dependencies to earliest versions that pass

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,11 +27,19 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # This is used for injecting additional tests for a specific python
+        # version and OS.
+        suffix: [""]
         include:
           - python-version: "3.7"
             os: ubuntu-latest
             extensive-tests: true
             TOXENV_SUFFIX: "-docs"
+          - python-version: "3.7"
+            os: ubuntu-latest
+            extensive-tests: true
+            suffix: "-min"
+            TOXENV_SUFFIX: "-min"
           - python-version: "3.8"
             os: ubuntu-latest
             TOX_EXTRA_COMMAND: "- isort --check-only --diff ."
@@ -80,23 +88,24 @@ jobs:
           task \
             TOX_EXTRA_COMMAND="${{ matrix.TOX_EXTRA_COMMAND }}" \
             OS=${{ matrix.os }} \
+            MATRIX_SUFFIX=${{ matrix.suffix }} \
             EXTENSIVE=${{ matrix.extensive-tests || 'false' }} \
             TOX_PYTHON_VERSION=${{ matrix.python-version }} \
             TOXENV_SUFFIX=${{ matrix.TOXENV_SUFFIX }} \
-            TOX_JUNIT_XML_PREFIX=${{ matrix.python-version }}-${{ matrix.os }}- \
+            TOX_JUNIT_XML_PREFIX=${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}- \
             gha:validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
         if: ${{ (success() || failure()) }}
         with:
-          name: ${{ matrix.python-version }}-${{ matrix.os }}-mypy-junit-xml
-          path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}-mypy-junit.xml
+          name: ${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-mypy-junit-xml
+          path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-mypy-junit.xml
       - uses: actions/upload-artifact@v3
         if: ${{ (success() || failure()) }}
         with:
-          name: ${{ matrix.python-version }}-${{ matrix.os }}-pytest-junit-xml
-          path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}-pytest-junit.xml
+          name: ${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-pytest-junit-xml
+          path: test_reports/${{ matrix.python-version }}-${{ matrix.os }}${{matrix.suffix}}-pytest-junit.xml
   extra-tasks:
     permissions:
       contents: read

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -241,7 +241,7 @@ tasks:
     desc: GitHub Actions Validation Workflow
     env:
       COVERALLS_PARALLEL: true
-      COVERALLS_FLAG_NAME: "{{.OS}}-{{.TOX_PYTHON_VERSION}}"
+      COVERALLS_FLAG_NAME: "{{.OS}}-{{.TOX_PYTHON_VERSION}}{{.MATRIX_SUFFIX}}"
       COVERALLS_SERVICE_NAME: '{{.COVERALLS_SERVICE_NAME | default (env "COVERALLS_SERVICE_NAME") | default "github"}}'
     cmds:
       - task: install:system-deps

--- a/devtools/constraints-min.txt
+++ b/devtools/constraints-min.txt
@@ -1,0 +1,9 @@
+# This file selects minimum versions to ensure that the test suite passes on
+# these versions.
+isodate==0.6.0
+pyparsing==2.1.0
+importlib-metadata==4.0.0
+berkeleydb==18.1.2
+networkx==2.0
+html5lib==1.0.1
+lxml==4.3.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1413,4 +1413,4 @@ networkx = ["networkx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "9ee7938916acb320dd76eba382b450a3e4e24dc1ae05569dbea3f2d35ab9bf75"
+content-hash = "9d02b28eb490584cc2bd1accb2006ea12ee19991511dadf9971204c9697c235f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,13 @@ rdfgraphisomorphism = 'rdflib.tools.graphisomorphism:main'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-isodate = "^0.6.1"
-pyparsing = "^3.0.9"
-importlib_metadata = {version = "^4.2.0", python = ">=3.7,<3.8"}
-berkeleydb = {version = "^18.1.5", optional = true}
-networkx = {version = "^2.6.2", optional = true}
-html5lib = {version = "^1.1", optional = true}
-lxml = {version = "^4.9.2", optional = true}
+isodate = "^0.6.0"
+pyparsing = ">=2.1.0,<4"
+importlib-metadata = {version = "^4.0.0", python = ">=3.7,<3.8"}
+berkeleydb = {version = "^18.1.0", optional = true}
+networkx = {version = "^2.0.0", optional = true}
+html5lib = {version = "^1.0", optional = true}
+lxml = {version = "^4.3.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = "22.12.0"

--- a/test/test_sparql/test_prefixed_name.py
+++ b/test/test_sparql/test_prefixed_name.py
@@ -76,10 +76,10 @@ def blank_graph() -> Graph:
     ["pname_ns", "pname", "expected_result"],
     itertools.chain(
         [
-            ("eg", "invalid/PN_PREFIX", pyparsing.exceptions.ParseException),
+            ("eg", "invalid/PN_PREFIX", pyparsing.ParseException),
             ("", "eg:a", Exception),
-            ("", ":invalid PN_LOCAL", pyparsing.exceptions.ParseException),
-            ("", ":invalid/PN_LOCAL", pyparsing.exceptions.ParseException),
+            ("", ":invalid PN_LOCAL", pyparsing.ParseException),
+            ("", ":invalid/PN_LOCAL", pyparsing.ParseException),
             ("", ":a:b:c", PNAME_PREFIX["a:b:c"]),
             ("", ":", URIRef(f"{PNAME_PREFIX}")),
             ("", ":a", PNAME_PREFIX.a),

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,4 @@
+# https://tox.wiki/en/latest/user_guide.html
 # https://tox.wiki/en/latest/config.html
 [tox]
 envlist =
@@ -55,6 +56,25 @@ commands_pre =
     poetry install --no-root --only=docs
 commands =
     poetry run sphinx-build -T -W -b html -d {envdir}/doctree docs docs/_build/html
+
+[testenv:py37-extensive-min]
+base = void
+deps =
+    pytest==7.*
+    pytest-cov==4.*
+setenv =
+    BERKELEYDB_DIR = /usr
+    COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage.{envname}}
+    PIP_CONSTRAINT = devtools/constraints-min.txt
+extras =
+    berkeleydb
+    networkx
+    lxml
+    html
+commands =
+    {envpython} --version
+    pip freeze
+    {posargs:{envpython} -m pytest -ra --tb=native {env:TOX_PYTEST_ARGS:--junit-xml=test_reports/{env:TOX_JUNIT_XML_PREFIX:}pytest-junit.xml --cov --cov-report=}}
 
 [testenv:precommit{,all}]
 skip_install = true


### PR DESCRIPTION
This adds a tox environment and GHA test matrix entry for testing the lowest allowed versions of dependencies and also lowered the lower bounds of dependency versions to the earliest versions that I could find that work.

The change of `pyparsing.exceptions.ParseException` -> `pyparsing.ParseException` is for compatibility with older pyparsing versions.